### PR TITLE
Add reset infos to transition

### DIFF
--- a/async_gym_agents/agents/off_policy_injector.py
+++ b/async_gym_agents/agents/off_policy_injector.py
@@ -27,6 +27,7 @@ class Transition:
     rewards: np.ndarray
     dones: np.ndarray
     infos: list[Dict]
+    reset_infos: list[Dict]
 
 
 class OffPolicyAlgorithmInjector(AsyncAgentInjector, OffPolicyAlgorithm):
@@ -173,6 +174,7 @@ class OffPolicyAlgorithmInjector(AsyncAgentInjector, OffPolicyAlgorithm):
             rewards = transition.rewards
             dones = transition.dones
             infos = transition.infos
+            reset_infos = transition.reset_infos
 
             # Update stats
             self.num_timesteps += 1
@@ -343,6 +345,7 @@ class InjectorWorker(InjectorWorkerBase):
                         single_slice(rewards, idx),
                         single_slice(dones, idx),
                         single_slice(infos, idx),
+                        single_slice(self.env.reset_infos, idx)
                     )
                 )
             last_obs = new_obs

--- a/async_gym_agents/agents/on_policy_injector.py
+++ b/async_gym_agents/agents/on_policy_injector.py
@@ -28,6 +28,7 @@ class Transition:
     dones: np.ndarray
     last_dones: np.ndarray
     infos: list[Dict]
+    reset_infos: list[Dict]
 
 
 class OnPolicyAlgorithmInjector(AsyncAgentInjector, OnPolicyAlgorithm):
@@ -112,6 +113,7 @@ class OnPolicyAlgorithmInjector(AsyncAgentInjector, OnPolicyAlgorithm):
             log_probs = transition.log_probs
             dones = transition.dones
             infos = transition.infos
+            reset_infos = transition.reset_infos
 
             self.num_timesteps += 1
 
@@ -235,6 +237,7 @@ class InjectorWorker(InjectorWorkerBase):
                         single_slice(dones, idx),
                         single_slice(last_dones, idx),
                         single_slice(infos, idx),
+                        single_slice(self.env.reset_infos, idx)
                     )
                 )
             last_obs = new_obs

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "async-gym-agents"
-version = "0.2.4"
+version = "0.2.5"
 description = "Async agents for Stable Baselines 3"
 authors = ["Jonas Peche <jonas.peche@aon.at>"]
 license = "Unlicense"


### PR DESCRIPTION
Pass `reset_infos` in Transition (makes it accessible in SB3 training callbacks)