### PR TITLE
Add mp_ctx `spawn` for the stable running on Linux.

### DIFF
--- a/async_gym_agents/agents/injector.py
+++ b/async_gym_agents/agents/injector.py
@@ -32,9 +32,6 @@ class MockLock:
         return False
 
 
-# use spawn always
-mp_ctx = multiprocessing.get_context("spawn")
-
 GenericState: TypeAlias = Namespace | SimpleNamespace
 GenericStateLock: TypeAlias = SemLock | MockLock
 GenericEvent: TypeAlias = MPEvent | threading.Event
@@ -51,6 +48,7 @@ class AsyncAgentInjector:
         skip_truncated: bool = False,
         queue_put_timeout: float = 60.0,
         worker_join_timeout: float = 120.0,
+        mp_method: Optional[str] = "spawn",
         **kwargs,
     ):
         """
@@ -59,9 +57,12 @@ class AsyncAgentInjector:
         :param skip_truncated: Skip episodes with truncated signal
         :param queue_put_timeout: Timeout when putting an episode before dropping
         :param worker_join_timeout: Shutdown time before killing the process
+        :param mp_method: Method to create processes. None for OS default. See https://docs.python.org/3/library/multiprocessing.html#contexts-and-start-methods
         """
         self.max_episodes_in_buffer = max_episodes_in_buffer
         self.use_mp = use_mp
+
+        self.mp_ctx = multiprocessing.get_context(mp_method)
 
         self._skip_truncated = skip_truncated
         self._queue_put_timeout = queue_put_timeout
@@ -74,7 +75,9 @@ class AsyncAgentInjector:
         # shared object (!)
         self._manager: Optional[multiprocessing.Manager] = None
         self._state: GenericState | None = None
-        self._state_lock: GenericStateLock | None = mp_ctx.Lock() if use_mp else MockLock()
+        self._state_lock: GenericStateLock | None = (
+            self.mp_ctx.Lock() if use_mp else MockLock()
+        )
         self._version = 0
 
         self._stop: GenericEvent | None = None
@@ -163,20 +166,20 @@ class AsyncAgentInjector:
 
         # Environment queue
         self._episode_queue = (
-            mp_ctx.Queue(maxsize=self.max_episodes_in_buffer)
+            self.mp_ctx.Queue(maxsize=self.max_episodes_in_buffer)
             if self.use_mp
             else queue.Queue(maxsize=self.max_episodes_in_buffer)
         )
 
         # Shared state for policy and metrics
-        self._manager = mp_ctx.Manager() if self.use_mp else None
+        self._manager = self.mp_ctx.Manager() if self.use_mp else None
         self._state = self._manager.Namespace() if self.use_mp else SimpleNamespace()
 
         self._state.total_episodes = 0
         self._state.discarded_episodes = 0
 
         # Stop signal
-        self._stop = mp_ctx.Event() if self.use_mp else threading.Event()
+        self._stop = self.mp_ctx.Event() if self.use_mp else threading.Event()
 
         self._initialized = True
 
@@ -192,7 +195,7 @@ class AsyncAgentInjector:
         policy_data = policy._get_constructor_parameters()
 
         for env_func in self.get_indexable_env().env_fns:
-            worker = (mp_ctx.Process if self.use_mp else threading.Thread)(
+            worker = (self.mp_ctx.Process if self.use_mp else threading.Thread)(
                 target=AsyncAgentInjector._run_worker,
                 kwargs=dict(
                     worker_class=self.get_worker_class(),
@@ -204,7 +207,7 @@ class AsyncAgentInjector:
                     worker_kwargs=self.get_worker_kwargs(),
                     use_mp=self.use_mp,
                     policy_class=policy_class,
-                    policy_data=policy_data
+                    policy_data=policy_data,
                 ),
             )
             worker.start()
@@ -227,7 +230,7 @@ class AsyncAgentInjector:
             "_initialized",
             "_initialized_workers",
             "_workers",
-            "_logger"
+            "_logger",
         ]
 
     def _fetch_transitions(self) -> List[Transition]:
@@ -360,12 +363,18 @@ class InjectorWorkerBase:
             version = self._state.version
             if self._policy_version != version:
                 # load policy weights to CPU
-                weights = torch.load(io.BytesIO(self._state.weights), map_location="cpu", weights_only=True)
+                weights = torch.load(
+                    io.BytesIO(self._state.weights),
+                    map_location="cpu",
+                    weights_only=True,
+                )
                 self.policy.load_state_dict(weights)
                 # turn off the train mode
                 self.policy.set_training_mode(False)
                 self._policy_version = version
-                self._logger.debug(f"policy loaded from state: version={self._policy_version}")
+                self._logger.debug(
+                    f"policy loaded from state: version={self._policy_version}"
+                )
 
     def _put_episode_with_timeout(self, episode):
         deadline = time.time() + self._queue_put_timeout
@@ -399,7 +408,10 @@ class InjectorWorkerBase:
         for episode in self.generate():
             self._state.total_episodes += 1
 
-            if episode[-1].infos[0].get("TimeLimit.truncated", False) and self._skip_truncated:
+            if (
+                episode[-1].infos[0].get("TimeLimit.truncated", False)
+                and self._skip_truncated
+            ):
                 self._state.discarded_episodes += 1
                 continue
 

--- a/async_gym_agents/agents/injector.py
+++ b/async_gym_agents/agents/injector.py
@@ -32,6 +32,9 @@ class MockLock:
         return False
 
 
+# use spawn always
+mp_ctx = multiprocessing.get_context("spawn")
+
 GenericState: TypeAlias = Namespace | SimpleNamespace
 GenericStateLock: TypeAlias = SemLock | MockLock
 GenericEvent: TypeAlias = MPEvent | threading.Event
@@ -71,7 +74,7 @@ class AsyncAgentInjector:
         # shared object (!)
         self._manager: Optional[multiprocessing.Manager] = None
         self._state: GenericState | None = None
-        self._state_lock: GenericStateLock | None = multiprocessing.Lock() if use_mp else MockLock()
+        self._state_lock: GenericStateLock | None = mp_ctx.Lock() if use_mp else MockLock()
         self._version = 0
 
         self._stop: GenericEvent | None = None
@@ -160,20 +163,20 @@ class AsyncAgentInjector:
 
         # Environment queue
         self._episode_queue = (
-            multiprocessing.Queue(maxsize=self.max_episodes_in_buffer)
+            mp_ctx.Queue(maxsize=self.max_episodes_in_buffer)
             if self.use_mp
             else queue.Queue(maxsize=self.max_episodes_in_buffer)
         )
 
         # Shared state for policy and metrics
-        self._manager = multiprocessing.Manager() if self.use_mp else None
+        self._manager = mp_ctx.Manager() if self.use_mp else None
         self._state = self._manager.Namespace() if self.use_mp else SimpleNamespace()
 
         self._state.total_episodes = 0
         self._state.discarded_episodes = 0
 
         # Stop signal
-        self._stop = multiprocessing.Event() if self.use_mp else threading.Event()
+        self._stop = mp_ctx.Event() if self.use_mp else threading.Event()
 
         self._initialized = True
 
@@ -189,7 +192,7 @@ class AsyncAgentInjector:
         policy_data = policy._get_constructor_parameters()
 
         for env_func in self.get_indexable_env().env_fns:
-            worker = (multiprocessing.Process if self.use_mp else threading.Thread)(
+            worker = (mp_ctx.Process if self.use_mp else threading.Thread)(
                 target=AsyncAgentInjector._run_worker,
                 kwargs=dict(
                     worker_class=self.get_worker_class(),

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "async-gym-agents"
-version = "0.2.6"
+version = "0.2.7"
 description = "Async agents for Stable Baselines 3"
 authors = ["Jonas Peche <jonas.peche@aon.at>"]
 license = "Unlicense"


### PR DESCRIPTION
The key idea is that when using fork, some objects are copied from a non-initial state and then cannot function correctly in another process. Therefore, I suggest switching to spawn consistently, as fork is causing issues for us. In our specific case, creating a new copy of the policy hangs indefinitely because some objects in the parameter dictionary are only partially initialized.